### PR TITLE
feat: add generics support for functions

### DIFF
--- a/compiler/ast.c
+++ b/compiler/ast.c
@@ -82,6 +82,14 @@ AstType *ast_type_tuple(AstType **elems, int count)
     return t;
 }
 
+AstType *ast_type_generic(const char *name)
+{
+    AstType *t = calloc(1, sizeof(AstType));
+    t->kind = TYPE_GENERIC;
+    t->name = strdup(name);
+    return t;
+}
+
 char *ast_strdup(const char *s, size_t len)
 {
     char *d = xmalloc(len + 1);
@@ -132,7 +140,7 @@ bool ast_types_equal(AstType *a, AstType *b)
         return a == b;
     if (a->kind != b->kind)
         return false;
-    if (a->kind == TYPE_NAMED)
+    if (a->kind == TYPE_NAMED || a->kind == TYPE_GENERIC)
         return strcmp(a->name, b->name) == 0;
     if (a->kind == TYPE_ARRAY)
         return ast_types_equal(a->element, b->element);
@@ -166,6 +174,9 @@ bool ast_types_compatible(AstType *from, AstType *to)
         return false;
     if (ast_types_equal(from, to))
         return true;
+    // Generic types are compatible with anything
+    if (from->kind == TYPE_GENERIC || to->kind == TYPE_GENERIC)
+        return true;
     if (from->kind == TYPE_INT && to->kind == TYPE_FLOAT)
         return true;
     if (from->kind == TYPE_ARRAY && to->kind == TYPE_ARRAY) {
@@ -197,6 +208,8 @@ const char *ast_type_str(AstType *t)
     case TYPE_VOID:
         return "void";
     case TYPE_NAMED:
+        return t->name;
+    case TYPE_GENERIC:
         return t->name;
     case TYPE_ARRAY:
         snprintf(buf, 256, "[%s]", ast_type_str(t->element));
@@ -266,6 +279,9 @@ static void print_type(AstType *t)
         printf("]");
         break;
     case TYPE_NAMED:
+        printf("%s", t->name);
+        break;
+    case TYPE_GENERIC:
         printf("%s", t->name);
         break;
     case TYPE_RESULT:

--- a/compiler/codegen.c
+++ b/compiler/codegen.c
@@ -46,6 +46,91 @@ static void emit_defers(CodeBuf *buf)
     }
 }
 
+// ---- Generic monomorphization tracking ----
+
+typedef struct {
+    char *fn_name;           // original generic function name
+    AstType **type_args;     // concrete type arguments
+    int type_arg_count;
+    char *mangled_name;      // mangled C function name
+    AstNode *fn_node;        // original AST node
+} MonoInstance;
+
+#define MAX_MONO 256
+static MonoInstance mono_instances[MAX_MONO];
+static int mono_count = 0;
+
+// Build a mangled name for a generic function instantiation
+static char *mono_mangle_name(const char *fn_name, AstType **type_args,
+                              int type_arg_count)
+{
+    char buf[512];
+    int pos = snprintf(buf, sizeof(buf), "%s", fn_name);
+    for (int i = 0; i < type_arg_count; i++) {
+        pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos, "_%s",
+                        ast_type_str(type_args[i]));
+    }
+    // Sanitize: replace special chars with _
+    for (int i = 0; buf[i]; i++) {
+        if (buf[i] == '<' || buf[i] == '>' || buf[i] == ',' ||
+            buf[i] == ' ' || buf[i] == '*' || buf[i] == '[' || buf[i] == ']' ||
+            buf[i] == '(' || buf[i] == ')')
+            buf[i] = '_';
+    }
+    return strdup(buf);
+}
+
+// Find or register a monomorphization instance. Returns the mangled name.
+static const char *mono_get_or_add(const char *fn_name, AstType **type_args,
+                                    int type_arg_count, AstNode *fn_node)
+{
+    // Check if already exists
+    for (int i = 0; i < mono_count; i++) {
+        if (strcmp(mono_instances[i].fn_name, fn_name) == 0 &&
+            mono_instances[i].type_arg_count == type_arg_count) {
+            bool match = true;
+            for (int j = 0; j < type_arg_count; j++) {
+                if (!ast_types_equal(mono_instances[i].type_args[j],
+                                     type_args[j])) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return mono_instances[i].mangled_name;
+        }
+    }
+    // Add new
+    if (mono_count >= MAX_MONO) {
+        fprintf(stderr, "Error: too many generic instantiations (max %d)\n",
+                MAX_MONO);
+        exit(1);
+    }
+    MonoInstance *m = &mono_instances[mono_count++];
+    m->fn_name = strdup(fn_name);
+    m->type_args = type_args;
+    m->type_arg_count = type_arg_count;
+    m->mangled_name = mono_mangle_name(fn_name, type_args, type_arg_count);
+    m->fn_node = fn_node;
+    return m->mangled_name;
+}
+
+// Find the AST node for a generic function by name
+static AstNode *find_generic_fn(AstNode *program, const char *name)
+{
+    for (int i = 0; i < program->as.program.decl_count; i++) {
+        AstNode *d = program->as.program.decls[i];
+        if (d->kind == NODE_FN_DECL &&
+            d->as.fn_decl.generic_param_count > 0 &&
+            strcmp(d->as.fn_decl.name, name) == 0) {
+            return d;
+        }
+    }
+    return NULL;
+}
+
+// Stored program root for generic fn lookup during codegen
+static AstNode *_codegen_program = NULL;
+
 // ---- Tuple typedef tracking ----
 static bool tuple_needs_drop(AstType *t);
 static bool type_needs_drop(AstType *t);
@@ -383,6 +468,10 @@ static void gen_type(CodeBuf *buf, AstType *t)
         break; // function pointers as void*
     case TYPE_TUPLE:
         emit(buf, "%s", tuple_type_name(t));
+        break;
+    case TYPE_GENERIC:
+        // Should not appear in final codegen (substituted during monomorphization)
+        emit(buf, "/* generic %s */ void*", t->name);
         break;
     }
 }
@@ -750,6 +839,15 @@ static void gen_expr(CodeBuf *buf, AstNode *node)
             }
             if (c_name) {
                 emit(buf, "%s(", c_name);
+            } else if (fn_name && node->as.call.type_arg_count > 0 &&
+                       node->as.call.type_args) {
+                // Generic function call — use monomorphized name
+                AstNode *gen_fn = _codegen_program
+                    ? find_generic_fn(_codegen_program, fn_name) : NULL;
+                const char *mangled = mono_get_or_add(
+                    fn_name, node->as.call.type_args,
+                    node->as.call.type_arg_count, gen_fn);
+                emit(buf, "%s(", mangled);
             } else {
                 gen_expr(buf, node->as.call.callee);
                 emit(buf, "(");
@@ -1289,25 +1387,35 @@ static void gen_stmt(CodeBuf *buf, AstNode *node)
         if (node->as.return_stmt.value) {
             gen_expr_pre(buf, node->as.return_stmt.value);
 
-            int tmp = buf->tmp_counter++;
             AstType *t = node->as.return_stmt.value->resolved_type;
 
-            emit_indent(buf);
-            gen_type(buf, t);
-            emit(buf, " _urus_ret_%d = ", tmp);
-            gen_expr(buf, node->as.return_stmt.value);
-            emit(buf, ";\n");
-
-            if (type_needs_drop(t) &&
-                node->as.return_stmt.value->kind == NODE_IDENT) {
+            // For generic types, return directly without temp variable
+            if (t && t->kind == TYPE_GENERIC) {
+                emit_defers(buf);
                 emit_indent(buf);
-                emit(buf, "%s = NULL; // move to _urus_ret_%d\n",
-                     node->as.return_stmt.value->as.ident.name, tmp);
-            }
+                emit(buf, "return ");
+                gen_expr(buf, node->as.return_stmt.value);
+                emit(buf, ";\n");
+            } else {
+                int tmp = buf->tmp_counter++;
 
-            emit_defers(buf);
-            emit_indent(buf);
-            emit(buf, "return _urus_ret_%d;\n", tmp);
+                emit_indent(buf);
+                gen_type(buf, t);
+                emit(buf, " _urus_ret_%d = ", tmp);
+                gen_expr(buf, node->as.return_stmt.value);
+                emit(buf, ";\n");
+
+                if (type_needs_drop(t) &&
+                    node->as.return_stmt.value->kind == NODE_IDENT) {
+                    emit_indent(buf);
+                    emit(buf, "%s = NULL; // move to _urus_ret_%d\n",
+                         node->as.return_stmt.value->as.ident.name, tmp);
+                }
+
+                emit_defers(buf);
+                emit_indent(buf);
+                emit(buf, "return _urus_ret_%d;\n", tmp);
+            }
         } else {
             emit_defers(buf);
             emit_indent(buf);
@@ -1551,8 +1659,56 @@ static void gen_fn_decl(CodeBuf *buf, AstNode *node)
 
 // ---- Program ----
 
+// Generate a monomorphized (specialized) version of a generic function
+static void gen_mono_fn(CodeBuf *buf, MonoInstance *m)
+{
+    AstNode *node = m->fn_node;
+    if (!node) return;
+
+    // Create substituted types for params and return type
+    int gpc = node->as.fn_decl.generic_param_count;
+    char **gnames = node->as.fn_decl.generic_params;
+
+    // Emit forward declaration
+    AstType *ret = sema_substitute_type(node->as.fn_decl.return_type,
+                                        gnames, m->type_args, gpc);
+    gen_type(buf, ret);
+    emit(buf, " %s(", m->mangled_name);
+    if (node->as.fn_decl.param_count == 0) {
+        emit(buf, "void");
+    } else {
+        for (int i = 0; i < node->as.fn_decl.param_count; i++) {
+            if (i > 0) emit(buf, ", ");
+            AstType *pt = sema_substitute_type(node->as.fn_decl.params[i].type,
+                                               gnames, m->type_args, gpc);
+            gen_type(buf, pt);
+            emit(buf, " %s", node->as.fn_decl.params[i].name);
+        }
+    }
+    emit(buf, ") {\n");
+
+    // Emit body
+    int saved_defer_count = defer_count;
+    defer_count = 0;
+    buf->indent++;
+    AstNode *body = node->as.fn_decl.body;
+    for (int i = 0; i < body->as.block.stmt_count; i++) {
+        gen_stmt(buf, body->as.block.stmts[i]);
+    }
+    if (defer_count > 0 && ret && ret->kind == TYPE_VOID) {
+        emit_defers(buf);
+    }
+    buf->indent--;
+    emit_indent(buf);
+    emit(buf, "}\n\n");
+    defer_count = saved_defer_count;
+}
+
 void codegen_generate(CodeBuf *buf, AstNode *program)
 {
+    _codegen_program = program;
+    mono_count = 0;
+
     emit(buf, "// Generated by: URUS Compiler, version %s\n",
          URUS_COMPILER_VERSION);
     emit(buf, "%.*s\n", urus_runtime_header_data_len, urus_runtime_header_data);
@@ -1630,10 +1786,10 @@ void codegen_generate(CodeBuf *buf, AstNode *program)
         }
     }
 
-    // Pass 3: function forward declarations
+    // Pass 3: function forward declarations (skip generic templates)
     for (int i = 0; i < program->as.program.decl_count; i++) {
         AstNode *d = program->as.program.decls[i];
-        if (d->kind == NODE_FN_DECL) {
+        if (d->kind == NODE_FN_DECL && d->as.fn_decl.generic_param_count == 0) {
             gen_fn_forward(buf, d);
         }
     }
@@ -1727,12 +1883,43 @@ void codegen_generate(CodeBuf *buf, AstNode *program)
         }
     }
 
-    // Pass 4: function definitions
+    // Pass 4: function definitions (skip generic templates)
     for (int i = 0; i < program->as.program.decl_count; i++) {
         AstNode *d = program->as.program.decls[i];
-        if (d->kind == NODE_FN_DECL) {
+        if (d->kind == NODE_FN_DECL && d->as.fn_decl.generic_param_count == 0) {
             gen_fn_decl(buf, d);
         }
+    }
+
+    // Pass 4b: emit monomorphized generic function specializations
+    // We iterate with index because gen_mono_fn may add new instances
+    for (int i = 0; i < mono_count; i++) {
+        // Emit forward decl first
+        MonoInstance *m = &mono_instances[i];
+        if (!m->fn_node) continue;
+        int gpc = m->fn_node->as.fn_decl.generic_param_count;
+        char **gnames = m->fn_node->as.fn_decl.generic_params;
+        AstType *ret = sema_substitute_type(
+            m->fn_node->as.fn_decl.return_type, gnames, m->type_args, gpc);
+        gen_type(buf, ret);
+        emit(buf, " %s(", m->mangled_name);
+        if (m->fn_node->as.fn_decl.param_count == 0) {
+            emit(buf, "void");
+        } else {
+            for (int j = 0; j < m->fn_node->as.fn_decl.param_count; j++) {
+                if (j > 0) emit(buf, ", ");
+                AstType *pt = sema_substitute_type(
+                    m->fn_node->as.fn_decl.params[j].type,
+                    gnames, m->type_args, gpc);
+                gen_type(buf, pt);
+                emit(buf, " %s", m->fn_node->as.fn_decl.params[j].name);
+            }
+        }
+        emit(buf, ");\n");
+    }
+    emit(buf, "\n");
+    for (int i = 0; i < mono_count; i++) {
+        gen_mono_fn(buf, &mono_instances[i]);
     }
 
     // C main wrapper — check if urus main accepts argc/argv

--- a/compiler/parser.c
+++ b/compiler/parser.c
@@ -127,6 +127,7 @@ static AstNode *parse_expr(Parser *p);
 static AstNode *parse_statement(Parser *p);
 static AstNode *parse_block(Parser *p);
 static AstType *parse_type(Parser *p);
+static bool try_parse_type_args(Parser *p, AstType ***out_args, int *out_count);
 
 // ---- Rune (macro) table ----
 typedef struct {
@@ -149,6 +150,31 @@ static RuneDef *find_rune(const char *name)
     }
     return NULL;
 }
+
+// ---- Generic parameter parsing ----
+// Parse <T, U, V> after function/struct name. Returns count via out param.
+static char **parse_generic_params(Parser *p, int *out_count)
+{
+    *out_count = 0;
+    if (!match(p, TOK_LT))
+        return NULL;
+    int cap = 4;
+    char **params = xmalloc(sizeof(char *) * (size_t)cap);
+    do {
+        if (*out_count >= cap) {
+            cap *= 2;
+            params = xrealloc(params, sizeof(char *) * (size_t)cap);
+        }
+        Token t = expect(p, TOK_IDENT, "expected generic type parameter name");
+        params[(*out_count)++] = tok_str(t);
+    } while (match(p, TOK_COMMA));
+    expect(p, TOK_GT, "expected '>' after generic parameters");
+    return params;
+}
+
+// Parse <int, str> type arguments in calls/type instantiations.
+// Returns count via out param.
+static AstType **parse_type_args(Parser *p, int *out_count);
 
 // ---- Type parsing ----
 
@@ -202,6 +228,25 @@ static AstType *parse_type(Parser *p)
     }
     error_at(p, current(p), "expected type");
     return ast_type_simple(TYPE_VOID);
+}
+
+// ---- Generic type argument parsing ----
+static AstType **parse_type_args(Parser *p, int *out_count)
+{
+    *out_count = 0;
+    if (!match(p, TOK_LT))
+        return NULL;
+    int cap = 4;
+    AstType **args = xmalloc(sizeof(AstType *) * (size_t)cap);
+    do {
+        if (*out_count >= cap) {
+            cap *= 2;
+            args = xrealloc(args, sizeof(AstType *) * (size_t)cap);
+        }
+        args[(*out_count)++] = parse_type(p);
+    } while (match(p, TOK_COMMA));
+    expect(p, TOK_GT, "expected '>' after type arguments");
+    return args;
 }
 
 // ---- F-string parsing ----
@@ -638,6 +683,12 @@ static AstNode *parse_primary(Parser *p)
             }
             p->pos = saved;
         }
+        // Check for generic struct literal: Ident<T, U> { ... }
+        AstType **struct_type_args = NULL;
+        int struct_type_arg_count = 0;
+        if (check(p, TOK_LT) && name[0] >= 'A' && name[0] <= 'Z') {
+            try_parse_type_args(p, &struct_type_args, &struct_type_arg_count);
+        }
         // Check for struct literal: Ident { field: val, ... } or Ident {} or
         // Ident { ..expr }
         if (check(p, TOK_LBRACE)) {
@@ -651,6 +702,8 @@ static AstNode *parse_primary(Parser *p)
                 n->as.struct_lit.fields = NULL;
                 n->as.struct_lit.field_count = 0;
                 n->as.struct_lit.spread = NULL;
+                n->as.struct_lit.type_args = struct_type_args;
+                n->as.struct_lit.type_arg_count = struct_type_arg_count;
                 return n;
             }
             // Spread-only: Ident { ..expr }
@@ -663,6 +716,8 @@ static AstNode *parse_primary(Parser *p)
                 n->as.struct_lit.fields = NULL;
                 n->as.struct_lit.field_count = 0;
                 n->as.struct_lit.spread = spread;
+                n->as.struct_lit.type_args = struct_type_args;
+                n->as.struct_lit.type_arg_count = struct_type_arg_count;
                 return n;
             }
             if (check(p, TOK_IDENT)) {
@@ -703,6 +758,8 @@ static AstNode *parse_primary(Parser *p)
                     n->as.struct_lit.fields = fields;
                     n->as.struct_lit.field_count = count;
                     n->as.struct_lit.spread = spread;
+                    n->as.struct_lit.type_args = struct_type_args;
+                    n->as.struct_lit.type_arg_count = struct_type_arg_count;
                     return n;
                 }
                 p->pos = saved2;
@@ -781,10 +838,87 @@ static AstNode *parse_primary(Parser *p)
     return ast_new(NODE_INT_LIT, t);
 }
 
+// Try to parse <Type, Type, ...> as generic type arguments.
+// Returns true if successfully parsed (and consumed tokens), false if not
+// (position restored).
+static bool try_parse_type_args(Parser *p, AstType ***out_args, int *out_count)
+{
+    int save_pos = p->pos;
+    bool save_err = p->had_error;
+    *out_count = 0;
+    *out_args = NULL;
+    if (!match(p, TOK_LT)) return false;
+    int cap = 4;
+    AstType **args = xmalloc(sizeof(AstType *) * (size_t)cap);
+    int count = 0;
+    // Simple heuristic: try to parse types until we hit '>'
+    // If we fail or don't find '>' followed by '(', restore
+    do {
+        if (at_end(p) || p->had_error) goto fail;
+        if (count >= cap) {
+            cap *= 2;
+            args = xrealloc(args, sizeof(AstType *) * (size_t)cap);
+        }
+        // Check if current token could be a type
+        Token t = current(p);
+        if (t.type != TOK_IDENT && t.type != TOK_INT && t.type != TOK_FLOAT &&
+            t.type != TOK_BOOL && t.type != TOK_STR && t.type != TOK_VOID &&
+            t.type != TOK_LBRACKET && t.type != TOK_LPAREN) {
+            goto fail;
+        }
+        args[count++] = parse_type(p);
+        if (p->had_error) goto fail;
+    } while (match(p, TOK_COMMA));
+    if (!match(p, TOK_GT)) goto fail;
+    // Must be followed by '(' for function call or '{' for struct literal
+    if (!check(p, TOK_LPAREN) && !check(p, TOK_LBRACE)) goto fail;
+    *out_args = args;
+    *out_count = count;
+    return true;
+fail:
+    free(args);
+    p->pos = save_pos;
+    p->had_error = save_err;
+    *out_count = 0;
+    *out_args = NULL;
+    return false;
+}
+
 static AstNode *parse_call(Parser *p)
 {
     AstNode *expr = parse_primary(p);
     while (true) {
+        // Check for generic type arguments: ident<Type, ...>(args)
+        if (expr->kind == NODE_IDENT && check(p, TOK_LT)) {
+            AstType **type_args = NULL;
+            int type_arg_count = 0;
+            if (try_parse_type_args(p, &type_args, &type_arg_count)) {
+                // Now expect '(' for function call
+                if (match(p, TOK_LPAREN)) {
+                    int cap = 4, count = 0;
+                    AstNode **args = xmalloc(sizeof(AstNode *) * (size_t)cap);
+                    if (!check(p, TOK_RPAREN)) {
+                        do {
+                            if (count >= cap) {
+                                cap *= 2;
+                                args = xrealloc(args,
+                                    sizeof(AstNode *) * (size_t)cap);
+                            }
+                            args[count++] = parse_expr(p);
+                        } while (match(p, TOK_COMMA));
+                    }
+                    expect(p, TOK_RPAREN, "expected ')' after arguments");
+                    AstNode *call = ast_new(NODE_CALL, previous(p));
+                    call->as.call.callee = expr;
+                    call->as.call.args = args;
+                    call->as.call.arg_count = count;
+                    call->as.call.type_args = type_args;
+                    call->as.call.type_arg_count = type_arg_count;
+                    expr = call;
+                    continue;
+                }
+            }
+        }
         if (match(p, TOK_LPAREN)) {
             int cap = 4, count = 0;
             AstNode **args = xmalloc(sizeof(AstNode *) * (size_t)cap);
@@ -1345,6 +1479,11 @@ static AstNode *parse_fn_decl(Parser *p)
 {
     expect(p, TOK_FN, "expected 'fn'");
     Token name = expect(p, TOK_IDENT, "expected function name");
+
+    // Parse optional generic parameters: fn foo<T, U>(...)
+    int generic_count = 0;
+    char **generic_params = parse_generic_params(p, &generic_count);
+
     expect(p, TOK_LPAREN, "expected '('");
 
     int cap = 4, count = 0;
@@ -1395,6 +1534,8 @@ static AstNode *parse_fn_decl(Parser *p)
     n->as.fn_decl.param_count = count;
     n->as.fn_decl.return_type = ret;
     n->as.fn_decl.body = body;
+    n->as.fn_decl.generic_params = generic_params;
+    n->as.fn_decl.generic_param_count = generic_count;
     return n;
 }
 
@@ -1402,6 +1543,11 @@ static AstNode *parse_struct_decl(Parser *p)
 {
     Token struct_tok = expect(p, TOK_STRUCT, "expected 'struct'");
     Token name = expect(p, TOK_IDENT, "expected struct name");
+
+    // Parse optional generic parameters: struct Pair<A, B> { ... }
+    int generic_count = 0;
+    char **generic_params = parse_generic_params(p, &generic_count);
+
     expect(p, TOK_LBRACE, "expected '{'");
 
     int cap = 4, count = 0;
@@ -1431,6 +1577,8 @@ static AstNode *parse_struct_decl(Parser *p)
     n->as.struct_decl.name = tok_str(name);
     n->as.struct_decl.fields = fields;
     n->as.struct_decl.field_count = count;
+    n->as.struct_decl.generic_params = generic_params;
+    n->as.struct_decl.generic_param_count = generic_count;
     return n;
 }
 

--- a/compiler/sema.c
+++ b/compiler/sema.c
@@ -136,6 +136,97 @@ SemaSymbol *scope_add(SemaScope *s, const char *name, Token tok)
     return sym;
 }
 
+// ---- Generic type substitution ----
+
+// Substitute TYPE_GENERIC nodes in a type tree with concrete types.
+// generic_names/concrete_types arrays must be parallel with count entries.
+AstType *sema_substitute_type(AstType *t, char **generic_names,
+                              AstType **concrete_types, int count)
+{
+    if (!t) return NULL;
+    if (t->kind == TYPE_GENERIC || t->kind == TYPE_NAMED) {
+        for (int i = 0; i < count; i++) {
+            if (strcmp(t->name, generic_names[i]) == 0)
+                return ast_type_clone(concrete_types[i]);
+        }
+        return ast_type_clone(t);
+    }
+    if (t->kind == TYPE_ARRAY) {
+        return ast_type_array(
+            sema_substitute_type(t->element, generic_names, concrete_types, count));
+    }
+    if (t->kind == TYPE_RESULT) {
+        return ast_type_result(
+            sema_substitute_type(t->ok_type, generic_names, concrete_types, count),
+            sema_substitute_type(t->err_type, generic_names, concrete_types, count));
+    }
+    if (t->kind == TYPE_TUPLE) {
+        AstType **elems = xmalloc(sizeof(AstType *) * (size_t)t->element_count);
+        for (int i = 0; i < t->element_count; i++)
+            elems[i] = sema_substitute_type(t->element_types[i], generic_names,
+                                            concrete_types, count);
+        return ast_type_tuple(elems, t->element_count);
+    }
+    if (t->kind == TYPE_FN) {
+        AstType **params = xmalloc(sizeof(AstType *) * (size_t)t->param_count);
+        for (int i = 0; i < t->param_count; i++)
+            params[i] = sema_substitute_type(t->param_types[i], generic_names,
+                                             concrete_types, count);
+        return ast_type_fn(params, t->param_count,
+            sema_substitute_type(t->return_type, generic_names, concrete_types, count));
+    }
+    return ast_type_clone(t);
+}
+
+// Try to infer generic type arguments from actual argument types.
+// Returns true if successful, fills inferred_types.
+static bool sema_infer_type_args(SemaSymbol *sym, AstType **arg_types,
+                                 int arg_count, AstType **inferred_types)
+{
+    // Initialize all as NULL
+    for (int i = 0; i < sym->generic_param_count; i++)
+        inferred_types[i] = NULL;
+
+    // For each parameter, try to match its type against the argument type
+    int check_count = arg_count < sym->param_count ? arg_count : sym->param_count;
+    for (int i = 0; i < check_count; i++) {
+        AstType *param_type = sym->params[i].type;
+        AstType *actual_type = arg_types[i];
+        if (!param_type || !actual_type) continue;
+
+        // Direct generic parameter match: param is T, arg is int → T = int
+        if (param_type->kind == TYPE_GENERIC || param_type->kind == TYPE_NAMED) {
+            for (int g = 0; g < sym->generic_param_count; g++) {
+                if (strcmp(param_type->name, sym->generic_params[g]) == 0) {
+                    if (!inferred_types[g]) {
+                        inferred_types[g] = actual_type;
+                    }
+                    break;
+                }
+            }
+        }
+        // Array<T> match: param is [T], arg is [int] → T = int
+        if (param_type->kind == TYPE_ARRAY && actual_type->kind == TYPE_ARRAY &&
+            param_type->element) {
+            for (int g = 0; g < sym->generic_param_count; g++) {
+                if (param_type->element->kind == TYPE_GENERIC &&
+                    strcmp(param_type->element->name, sym->generic_params[g]) == 0) {
+                    if (!inferred_types[g] && actual_type->element) {
+                        inferred_types[g] = actual_type->element;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    // Check all type params were inferred
+    for (int i = 0; i < sym->generic_param_count; i++) {
+        if (!inferred_types[i]) return false;
+    }
+    return true;
+}
+
 // ---- Expression type checking ----
 
 static AstType *set_type(AstNode *node, AstType *t)
@@ -389,8 +480,70 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node)
         }
 
         sym->is_referenced = true;
-        int min_args = 0; // minimal arguments (argument with default value will
-                          // not counted)
+
+        // Generic function handling
+        AstType **resolved_param_types = NULL;
+        AstType *resolved_return_type = NULL;
+        bool is_generic = sym->generic_param_count > 0;
+
+        if (is_generic) {
+            AstType **type_args = NULL;
+            int type_arg_count = 0;
+
+            if (node->as.call.type_arg_count > 0) {
+                // Explicit type arguments: fn<int, str>(...)
+                type_args = node->as.call.type_args;
+                type_arg_count = node->as.call.type_arg_count;
+                if (type_arg_count != sym->generic_param_count) {
+                    sema_error(ctx, &node->tok,
+                               "'%s' expects %d type arguments, got %d",
+                               fn_name, sym->generic_param_count,
+                               type_arg_count);
+                }
+            } else {
+                // Infer type arguments from actual arguments
+                // First, check all argument expressions to get their types
+                AstType **arg_types = xmalloc(
+                    sizeof(AstType *) * (size_t)(node->as.call.arg_count + 1));
+                for (int i = 0; i < node->as.call.arg_count; i++)
+                    arg_types[i] = check_expr(ctx, node->as.call.args[i]);
+
+                type_args = xmalloc(
+                    sizeof(AstType *) * (size_t)sym->generic_param_count);
+                type_arg_count = sym->generic_param_count;
+                if (!sema_infer_type_args(sym, arg_types,
+                                          node->as.call.arg_count, type_args)) {
+                    sema_error(ctx, &node->tok,
+                               "cannot infer type arguments for generic "
+                               "function '%s'; use explicit type arguments",
+                               fn_name);
+                    xfree(arg_types);
+                    xfree(type_args);
+                    return set_type(node, ast_type_simple(TYPE_VOID));
+                }
+                xfree(arg_types);
+            }
+
+            // Substitute generic params with concrete types
+            if (type_arg_count == sym->generic_param_count) {
+                resolved_param_types = xmalloc(
+                    sizeof(AstType *) * (size_t)sym->param_count);
+                for (int i = 0; i < sym->param_count; i++) {
+                    resolved_param_types[i] = sema_substitute_type(
+                        sym->params[i].type, sym->generic_params,
+                        type_args, type_arg_count);
+                }
+                resolved_return_type = sema_substitute_type(
+                    sym->return_type, sym->generic_params,
+                    type_args, type_arg_count);
+            }
+
+            // Store resolved type args on the call node for codegen
+            node->as.call.type_args = type_args;
+            node->as.call.type_arg_count = type_arg_count;
+        }
+
+        int min_args = 0;
         for (int i = 0; i < sym->param_count; i++) {
             if (sym->params[i].default_value == NULL) {
                 min_args++;
@@ -405,20 +558,25 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node)
         }
 
         for (int i = 0; i < node->as.call.arg_count; i++) {
-            AstType *at = check_expr(ctx, node->as.call.args[i]);
-            if (sym->param_count > 0 && i < sym->param_count && sym->params) {
-                if (!ast_types_equal(at, sym->params[i].type)) {
-                    if (sym->params[i].type &&
-                        sym->params[i].type->kind != TYPE_VOID) {
-                        sema_error(
-                            ctx, &node->as.call.args[i]->tok,
-                            "argument %d of '%s': expected '%s', got '%s'",
-                            i + 1, fn_name, ast_type_str(sym->params[i].type),
-                            ast_type_str(at));
-                    }
+            AstType *at = is_generic ? node->as.call.args[i]->resolved_type
+                                     : check_expr(ctx, node->as.call.args[i]);
+            AstType *expected = (is_generic && resolved_param_types)
+                                    ? resolved_param_types[i]
+                                    : (sym->param_count > 0 && i < sym->param_count
+                                           ? sym->params[i].type
+                                           : NULL);
+            if (at && expected && expected->kind != TYPE_VOID) {
+                if (!ast_types_compatible(at, expected)) {
+                    sema_error(
+                        ctx, &node->as.call.args[i]->tok,
+                        "argument %d of '%s': expected '%s', got '%s'",
+                        i + 1, fn_name, ast_type_str(expected),
+                        ast_type_str(at));
                 }
             }
         }
+
+        if (resolved_param_types) xfree(resolved_param_types);
 
         // Inject default parameter values to args
         if (node->as.call.arg_count < sym->param_count &&
@@ -445,7 +603,8 @@ static AstType *check_expr(SemaCtx *ctx, AstNode *node)
         }
 
         // Special: unwrap returns the ok_type of the Result argument
-        AstType *final_return = sym->return_type;
+        AstType *final_return = resolved_return_type ? resolved_return_type
+                                                     : sym->return_type;
         if (fn_name && strcmp(fn_name, "unwrap") == 0 &&
             node->as.call.arg_count > 0) {
             AstType *arg_type = node->as.call.args[0]->resolved_type;
@@ -1156,6 +1315,8 @@ bool sema_analyze(AstNode *program, const char *filename)
             s->fields = d->as.struct_decl.fields;
             s->field_count = d->as.struct_decl.field_count;
             s->type = ast_type_named(d->as.struct_decl.name);
+            s->generic_params = d->as.struct_decl.generic_params;
+            s->generic_param_count = d->as.struct_decl.generic_param_count;
         } else if (d->kind == NODE_ENUM_DECL) {
             if (scope_lookup_local(global, d->as.enum_decl.name)) {
                 sema_error(&ctx, &d->tok, "duplicate enum '%s'",
@@ -1176,10 +1337,22 @@ bool sema_analyze(AstNode *program, const char *filename)
             } else if (d->as.fn_decl.return_type->kind == TYPE_NAMED &&
                        !scope_lookup(ctx.current,
                                      d->as.fn_decl.return_type->name)) {
-                sema_error(&ctx, &d->tok,
-                           "function '%s' has unknown return type '%s'",
-                           d->as.fn_decl.name, d->as.fn_decl.return_type->name);
-                continue;
+                // Check if return type is a generic param — that's OK
+                bool is_generic_param = false;
+                for (int g = 0; g < d->as.fn_decl.generic_param_count; g++) {
+                    if (strcmp(d->as.fn_decl.return_type->name,
+                              d->as.fn_decl.generic_params[g]) == 0) {
+                        is_generic_param = true;
+                        break;
+                    }
+                }
+                if (!is_generic_param) {
+                    sema_error(&ctx, &d->tok,
+                               "function '%s' has unknown return type '%s'",
+                               d->as.fn_decl.name,
+                               d->as.fn_decl.return_type->name);
+                    continue;
+                }
             }
             SemaSymbol *s = scope_add(global, d->as.fn_decl.name, d->tok);
             s->tag = FN_SYM_TAG;
@@ -1187,6 +1360,8 @@ bool sema_analyze(AstNode *program, const char *filename)
             s->params = d->as.fn_decl.params;
             s->param_count = d->as.fn_decl.param_count;
             s->return_type = d->as.fn_decl.return_type;
+            s->generic_params = d->as.fn_decl.generic_params;
+            s->generic_param_count = d->as.fn_decl.generic_param_count;
         } else if (d->kind == NODE_CONST_DECL) {
             if (scope_lookup_local(global, d->as.const_decl.name)) {
                 sema_error(&ctx, &d->tok, "duplicate constant '%s'",
@@ -1248,6 +1423,15 @@ bool sema_analyze(AstNode *program, const char *filename)
             SemaScope *fn_scope = scope_new(global);
             ctx.current = fn_scope;
             ctx.current_fn_name = d->as.fn_decl.name;
+
+            // Register generic type parameters in function scope
+            for (int g = 0; g < d->as.fn_decl.generic_param_count; g++) {
+                SemaSymbol *gs = scope_add(fn_scope,
+                    d->as.fn_decl.generic_params[g], d->tok);
+                gs->tag = TYPE_SYM_TAG;
+                gs->alias_type = ast_type_generic(d->as.fn_decl.generic_params[g]);
+                gs->is_referenced = true;
+            }
 
             // Resolve type aliases in return type and params
             d->as.fn_decl.return_type =

--- a/compiler/urusc.h
+++ b/compiler/urusc.h
@@ -105,6 +105,7 @@ typedef enum {
     TYPE_RESULT, // Result<ok_type, err_type>
     TYPE_FN, // fn(T1, T2) -> R
     TYPE_TUPLE, // (T1, T2, ...)
+    TYPE_GENERIC, // generic type parameter (T, U, etc.)
 } TypeKind;
 
 struct AstType {
@@ -226,6 +227,9 @@ struct AstNode {
             int param_count;
             AstType *return_type;
             AstNode *body; // block
+            // Generics
+            char **generic_params; // e.g. ["T", "U"]
+            int generic_param_count;
         } fn_decl;
 
         // NODE_STRUCT_DECL
@@ -233,6 +237,9 @@ struct AstNode {
             char *name;
             Param *fields;
             int field_count;
+            // Generics
+            char **generic_params; // e.g. ["T"]
+            int generic_param_count;
         } struct_decl;
 
         // NODE_BLOCK
@@ -340,6 +347,9 @@ struct AstNode {
             AstNode *callee;
             AstNode **args;
             int arg_count;
+            // Generics: explicit type arguments e.g. max<int>(a, b)
+            AstType **type_args;
+            int type_arg_count;
         } call;
 
         // NODE_FIELD_ACCESS
@@ -391,6 +401,9 @@ struct AstNode {
             FieldInit *fields;
             int field_count;
             AstNode *spread;
+            // Generics: type arguments e.g. Pair<int, str> { ... }
+            AstType **type_args;
+            int type_arg_count;
         } struct_lit;
 
         // NODE_ENUM_DECL
@@ -487,6 +500,11 @@ AstType *ast_type_result(AstType *ok_type, AstType *err_type);
 AstType *ast_type_fn(AstType **param_types, int param_count,
                      AstType *return_type);
 AstType *ast_type_tuple(AstType **elems, int count);
+AstType *ast_type_generic(const char *name);
+
+// Generic type substitution (used by both sema and codegen)
+AstType *sema_substitute_type(AstType *t, char **generic_names,
+                              AstType **concrete_types, int count);
 char *ast_strdup(const char *s, size_t len);
 
 // Type utilities
@@ -565,6 +583,10 @@ typedef struct {
 
     // alias (type ID = int;);
     AstType *alias_type;
+
+    // generics
+    char **generic_params;
+    int generic_param_count;
 } SemaSymbol;
 
 typedef struct Scope {

--- a/tests/run/generics.urus
+++ b/tests/run/generics.urus
@@ -1,0 +1,21 @@
+fn max_val<T>(a: T, b: T): T {
+    if a > b {
+        return a;
+    }
+    return b;
+}
+
+fn identity<T>(x: T): T {
+    return x;
+}
+
+fn main(): void {
+    let a: int = max_val<int>(10, 20);
+    print(a);
+    let b: float = max_val<float>(3.14, 2.71);
+    print(b);
+    let c: str = identity<str>("hello generics");
+    print(c);
+    let d: int = identity<int>(42);
+    print(d);
+}


### PR DESCRIPTION
Closes #157

## Summary
- Generic function declarations: `fn max<T>(a: T, b: T): T`
- Explicit type arguments: `max<int>(10, 20)`
- Type inference from arguments
- Monomorphization codegen (generates specialized C functions per type instantiation)

## Test plan
- [x] `tests/run/generics.urus` compiles with `--emit-c`
- [x] Generates correct specialized functions: `max_val_int`, `max_val_float`, `identity_str`, `identity_int`