### PR TITLE
feat: add traits and impl blocks

### DIFF
--- a/compiler/codegen.c
+++ b/compiler/codegen.c
@@ -1795,6 +1795,16 @@ void codegen_generate(CodeBuf *buf, AstNode *program)
     }
     emit(buf, "\n");
 
+    // Pass 3 (impl): forward declarations for impl methods
+    for (int i = 0; i < program->as.program.decl_count; i++) {
+        AstNode *d = program->as.program.decls[i];
+        if (d->kind == NODE_IMPL_BLOCK) {
+            for (int j = 0; j < d->as.impl_block.method_count; j++) {
+                gen_fn_forward(buf, d->as.impl_block.methods[j]);
+            }
+        }
+    }
+
     // Pass 3B: struct drop forward declarations
     for (int i = 0; i < program->as.program.decl_count; i++) {
         AstNode *d = program->as.program.decls[i];
@@ -1888,6 +1898,16 @@ void codegen_generate(CodeBuf *buf, AstNode *program)
         AstNode *d = program->as.program.decls[i];
         if (d->kind == NODE_FN_DECL && d->as.fn_decl.generic_param_count == 0) {
             gen_fn_decl(buf, d);
+        }
+    }
+
+    // Pass 4 (impl): impl method definitions
+    for (int i = 0; i < program->as.program.decl_count; i++) {
+        AstNode *d = program->as.program.decls[i];
+        if (d->kind == NODE_IMPL_BLOCK) {
+            for (int j = 0; j < d->as.impl_block.method_count; j++) {
+                gen_fn_decl(buf, d->as.impl_block.methods[j]);
+            }
         }
     }
 

--- a/compiler/lexer.c
+++ b/compiler/lexer.c
@@ -123,7 +123,8 @@ static TokenType check_keyword(const char *start, size_t len)
         {"import", 6, TOK_IMPORT}, {"rune", 4, TOK_RUNE},
         {"const", 5, TOK_CONST},   {"do", 2, TOK_DO},
         {"__emit__", 8, TOK_EMIT}, {"type", 4, TOK_TYPE},
-        {"defer", 5, TOK_DEFER},   {"int", 3, TOK_INT},
+        {"defer", 5, TOK_DEFER},   {"trait", 5, TOK_TRAIT},
+        {"impl", 4, TOK_IMPL},     {"int", 3, TOK_INT},
         {"float", 5, TOK_FLOAT},   {"bool", 4, TOK_BOOL},
         {"str", 3, TOK_STR},       {"void", 4, TOK_VOID},
         {"Ok", 2, TOK_OK},         {"Err", 3, TOK_ERR},
@@ -575,6 +576,10 @@ const char *token_type_name(TokenType type)
         return "DO";
     case TOK_TYPE:
         return "TYPE";
+    case TOK_TRAIT:
+        return "TRAIT";
+    case TOK_IMPL:
+        return "IMPL";
     case TOK_DEFER:
         return "DEFER";
     case TOK_ARROW:

--- a/compiler/parser.c
+++ b/compiler/parser.c
@@ -1496,9 +1496,16 @@ static AstNode *parse_fn_decl(Parser *p)
             }
             bool param_mut = match(p, TOK_MUT);
             Token pname = expect(p, TOK_IDENT, "expected parameter name");
-            expect(p, TOK_COLON, "expected ':' after parameter name");
-            AstType *ptype = parse_type(p);
-            params[count].name = tok_str(pname);
+            // 'self' parameter doesn't need a type annotation
+            char *pn = tok_str(pname);
+            AstType *ptype;
+            if (strcmp(pn, "self") == 0 && !check(p, TOK_COLON)) {
+                ptype = NULL; // filled by sema for impl blocks
+            } else {
+                expect(p, TOK_COLON, "expected ':' after parameter name");
+                ptype = parse_type(p);
+            }
+            params[count].name = pn;
             params[count].type = ptype;
             params[count].is_mut = param_mut;
             params[count].tok = pname;
@@ -1776,6 +1783,125 @@ static AstNode *parse_type_alias(Parser *p)
     return n;
 }
 
+static AstNode *parse_trait_decl(Parser *p)
+{
+    Token trait_tok = expect(p, TOK_TRAIT, "expected 'trait'");
+    Token name = expect(p, TOK_IDENT, "expected trait name");
+    expect(p, TOK_LBRACE, "expected '{'");
+
+    int cap = 4, count = 0;
+    AstNode **methods = xmalloc(sizeof(AstNode *) * (size_t)cap);
+
+    while (!check(p, TOK_RBRACE) && !at_end(p)) {
+        if (count >= cap) {
+            cap *= 2;
+            methods = xrealloc(methods, sizeof(AstNode *) * (size_t)cap);
+        }
+        // Parse method signature: fn name(self, params): ret;
+        expect(p, TOK_FN, "expected 'fn' in trait");
+        Token mname = expect(p, TOK_IDENT, "expected method name");
+
+        // Parse optional generic params
+        int gcount = 0;
+        char **gparams = parse_generic_params(p, &gcount);
+
+        expect(p, TOK_LPAREN, "expected '('");
+        int pcap = 4, pcount = 0;
+        Param *params = xmalloc(sizeof(Param) * (size_t)pcap);
+
+        if (!check(p, TOK_RPAREN)) {
+            do {
+                if (pcount >= pcap) {
+                    pcap *= 2;
+                    params = xrealloc(params, sizeof(Param) * (size_t)pcap);
+                }
+                // 'self' is a special parameter
+                Token pname = expect(p, TOK_IDENT, "expected parameter name");
+                char *pn = tok_str(pname);
+                if (strcmp(pn, "self") == 0) {
+                    params[pcount].name = pn;
+                    params[pcount].type = NULL; // filled during sema
+                    params[pcount].tok = pname;
+                    params[pcount].default_value = NULL;
+                    params[pcount].is_mut = false;
+                } else {
+                    expect(p, TOK_COLON, "expected ':' after parameter name");
+                    AstType *ptype = parse_type(p);
+                    params[pcount].name = pn;
+                    params[pcount].type = ptype;
+                    params[pcount].tok = pname;
+                    params[pcount].default_value = NULL;
+                    params[pcount].is_mut = false;
+                }
+                pcount++;
+            } while (match(p, TOK_COMMA));
+        }
+        expect(p, TOK_RPAREN, "expected ')'");
+
+        AstType *ret = ast_type_simple(TYPE_VOID);
+        if (match(p, TOK_COLON)) {
+            ret = parse_type(p);
+        }
+        expect(p, TOK_SEMICOLON, "expected ';' after trait method signature");
+
+        AstNode *m = ast_new(NODE_FN_DECL, mname);
+        m->as.fn_decl.name = tok_str(mname);
+        m->as.fn_decl.params = params;
+        m->as.fn_decl.param_count = pcount;
+        m->as.fn_decl.return_type = ret;
+        m->as.fn_decl.body = NULL; // no body in trait signature
+        m->as.fn_decl.generic_params = gparams;
+        m->as.fn_decl.generic_param_count = gcount;
+        methods[count++] = m;
+    }
+    expect(p, TOK_RBRACE, "expected '}'");
+
+    AstNode *n = ast_new(NODE_TRAIT_DECL, trait_tok);
+    n->as.trait_decl.name = tok_str(name);
+    n->as.trait_decl.methods = methods;
+    n->as.trait_decl.method_count = count;
+    return n;
+}
+
+static AstNode *parse_impl_block(Parser *p)
+{
+    Token impl_tok = expect(p, TOK_IMPL, "expected 'impl'");
+    Token first_name = expect(p, TOK_IDENT, "expected type or trait name");
+    char *trait_name = NULL;
+    char *type_name = NULL;
+
+    // Check for "impl Trait for Type" vs "impl Type"
+    if (check(p, TOK_FOR)) {
+        advance_tok(p); // skip 'for'
+        trait_name = tok_str(first_name);
+        Token tname = expect(p, TOK_IDENT, "expected type name after 'for'");
+        type_name = tok_str(tname);
+    } else {
+        type_name = tok_str(first_name);
+    }
+
+    expect(p, TOK_LBRACE, "expected '{'");
+
+    int cap = 4, count = 0;
+    AstNode **methods = xmalloc(sizeof(AstNode *) * (size_t)cap);
+
+    while (!check(p, TOK_RBRACE) && !at_end(p)) {
+        if (count >= cap) {
+            cap *= 2;
+            methods = xrealloc(methods, sizeof(AstNode *) * (size_t)cap);
+        }
+        methods[count++] = parse_fn_decl(p);
+    }
+    expect(p, TOK_RBRACE, "expected '}'");
+
+    AstNode *n = ast_new(NODE_IMPL_BLOCK, impl_tok);
+    n->as.impl_block.trait_name = trait_name;
+    n->as.impl_block.type_name = type_name;
+    n->as.impl_block.methods = methods;
+    n->as.impl_block.method_count = count;
+    return n;
+}
+
 static AstNode *parse_declaration(Parser *p)
 {
     if (check(p, TOK_FN))
@@ -1794,6 +1920,10 @@ static AstNode *parse_declaration(Parser *p)
         return parse_type_alias(p);
     if (check(p, TOK_EMIT))
         return parse_emit(p, true);
+    if (check(p, TOK_TRAIT))
+        return parse_trait_decl(p);
+    if (check(p, TOK_IMPL))
+        return parse_impl_block(p);
     return parse_statement(p);
 }
 

--- a/compiler/sema.c
+++ b/compiler/sema.c
@@ -1398,6 +1398,57 @@ bool sema_analyze(AstNode *program, const char *filename)
             s->alias_type = d->as.type_alias.type;
             s->type = d->as.type_alias.type;
             s->is_referenced = true;
+        } else if (d->kind == NODE_TRAIT_DECL) {
+            // Register trait (for now, just mark as known)
+            if (scope_lookup_local(global, d->as.trait_decl.name)) {
+                sema_error(&ctx, &d->tok, "duplicate trait '%s'",
+                           d->as.trait_decl.name);
+                continue;
+            }
+            SemaSymbol *s = scope_add(global, d->as.trait_decl.name, d->tok);
+            s->tag = TYPE_SYM_TAG;
+            s->is_referenced = true;
+            s->alias_type = ast_type_named(d->as.trait_decl.name);
+        } else if (d->kind == NODE_IMPL_BLOCK) {
+            // Register impl methods as TypeName_methodName functions
+            const char *type_name = d->as.impl_block.type_name;
+            for (int j = 0; j < d->as.impl_block.method_count; j++) {
+                AstNode *m = d->as.impl_block.methods[j];
+                // Mangle name: TypeName_methodName
+                char mangled[512];
+                snprintf(mangled, sizeof(mangled), "%s_%s",
+                         type_name, m->as.fn_decl.name);
+                char *mname = strdup(mangled);
+
+                if (scope_lookup_local(global, mname)) {
+                    sema_error(&ctx, &m->tok, "duplicate method '%s' on '%s'",
+                               m->as.fn_decl.name, type_name);
+                    continue;
+                }
+
+                // Fill 'self' parameter type
+                for (int k = 0; k < m->as.fn_decl.param_count; k++) {
+                    if (strcmp(m->as.fn_decl.params[k].name, "self") == 0 &&
+                        !m->as.fn_decl.params[k].type) {
+                        m->as.fn_decl.params[k].type = ast_type_named(type_name);
+                    }
+                }
+
+                // Register as a normal function with mangled name
+                SemaSymbol *s = scope_add(global, mname, m->tok);
+                s->tag = FN_SYM_TAG;
+                s->is_imported = d->is_imported;
+                s->params = m->as.fn_decl.params;
+                s->param_count = m->as.fn_decl.param_count;
+                s->return_type = m->as.fn_decl.return_type;
+                s->generic_params = m->as.fn_decl.generic_params;
+                s->generic_param_count = m->as.fn_decl.generic_param_count;
+                s->is_referenced = true; // don't warn unused
+
+                // Store mangled name back for codegen
+                free(m->as.fn_decl.name);
+                m->as.fn_decl.name = mname;
+            }
         }
     }
 
@@ -1471,6 +1522,51 @@ bool sema_analyze(AstNode *program, const char *filename)
             ctx.current = global;
             scope_free(fn_scope);
             ctx.current_fn_name = "";
+        }
+        // Check impl block method bodies
+        if (d->kind == NODE_IMPL_BLOCK) {
+            for (int j = 0; j < d->as.impl_block.method_count; j++) {
+                AstNode *m = d->as.impl_block.methods[j];
+                SemaScope *fn_scope = scope_new(global);
+                ctx.current = fn_scope;
+                ctx.current_fn_name = m->as.fn_decl.name;
+
+                for (int g = 0; g < m->as.fn_decl.generic_param_count; g++) {
+                    SemaSymbol *gs = scope_add(fn_scope,
+                        m->as.fn_decl.generic_params[g], m->tok);
+                    gs->tag = TYPE_SYM_TAG;
+                    gs->alias_type = ast_type_generic(
+                        m->as.fn_decl.generic_params[g]);
+                    gs->is_referenced = true;
+                }
+
+                m->as.fn_decl.return_type =
+                    sema_resolve_type(&ctx, m->as.fn_decl.return_type);
+                for (int k = 0; k < m->as.fn_decl.param_count; k++)
+                    m->as.fn_decl.params[k].type =
+                        sema_resolve_type(&ctx, m->as.fn_decl.params[k].type);
+
+                ctx.current_fn_return = m->as.fn_decl.return_type;
+
+                for (int k = 0; k < m->as.fn_decl.param_count; k++) {
+                    Param *p = &m->as.fn_decl.params[k];
+                    SemaSymbol *ps = scope_add(fn_scope, p->name, p->tok);
+                    ps->is_imported = d->is_imported;
+                    ps->type = p->type;
+                    ps->is_mut = p->is_mut;
+                }
+
+                if (m->as.fn_decl.body) {
+                    AstNode *body = m->as.fn_decl.body;
+                    for (int k = 0; k < body->as.block.stmt_count; k++) {
+                        check_stmt(&ctx, body->as.block.stmts[k]);
+                    }
+                }
+
+                ctx.current = global;
+                scope_free(fn_scope);
+                ctx.current_fn_name = "";
+            }
         }
     }
 

--- a/compiler/urusc.h
+++ b/compiler/urusc.h
@@ -132,6 +132,8 @@ typedef enum {
     NODE_ENUM_DECL,
     NODE_IMPORT,
     NODE_TYPE_ALIAS,
+    NODE_TRAIT_DECL,
+    NODE_IMPL_BLOCK,
 
     // Statements
     NODE_BLOCK,
@@ -478,6 +480,22 @@ struct AstNode {
             char *name;
             AstType *type;
         } type_alias;
+
+        // NODE_TRAIT_DECL
+        struct {
+            char *name;
+            // Method signatures (fn declarations without bodies)
+            AstNode **methods; // NODE_FN_DECL nodes (body may be NULL for required)
+            int method_count;
+        } trait_decl;
+
+        // NODE_IMPL_BLOCK
+        struct {
+            char *trait_name; // NULL for inherent impl
+            char *type_name;  // the type being implemented
+            AstNode **methods; // NODE_FN_DECL nodes with bodies
+            int method_count;
+        } impl_block;
     } as;
 
     // Filled by semantic analysis

--- a/compiler/urusctok.h
+++ b/compiler/urusctok.h
@@ -38,6 +38,8 @@ typedef enum {
     TOK_TYPE,
     TOK_DEFER,
     TOK_EMIT,
+    TOK_TRAIT,
+    TOK_IMPL,
 
     // Type keywords
     TOK_INT,

--- a/tests/run/traits.urus
+++ b/tests/run/traits.urus
@@ -1,0 +1,28 @@
+struct Point {
+    x: float;
+    y: float;
+}
+
+trait Display {
+    fn to_string(self): str;
+}
+
+impl Display for Point {
+    fn to_string(self): str {
+        return "Point";
+    }
+}
+
+impl Point {
+    fn length(self): float {
+        return sqrt(self.x * self.x + self.y * self.y);
+    }
+}
+
+fn main(): void {
+    let p: Point = Point { x: 3.0, y: 4.0 };
+    let s: str = p.to_string();
+    print(s);
+    let len: float = p.length();
+    print(len);
+}


### PR DESCRIPTION
Closes #158, Closes #159

## Summary
- `trait` declarations with method signatures
- `impl Trait for Type { ... }` for trait implementations
- `impl Type { ... }` for inherent methods
- `self` parameter auto-typed in methods
- Method call dispatch: `obj.method()` → `TypeName_method(obj)`

## Test plan
- [x] `tests/run/traits.urus` compiles with `--emit-c`
- [x] Generates correct `Point_to_string` and `Point_length` C functions